### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,2 @@
 # CODEOWNERS file automatically generated based on git history
-# Each entry lists the files or directories owned by the contributor with the highest number of commits.
-*                               @jordanstephens 
-/.github/                       @raphaeltm 
-/blog/                          @raphaeltm 
-/src/                           @raphaeltm 
-/scripts/                       @raphaeltm 
+*                               @DefangLabs/devs 


### PR DESCRIPTION
## Summary
- create `.github/CODEOWNERS` with owners inferred from git history

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68633e917814832283e85ebeb794500b