### PR TITLE
alphabetize sidebar items

### DIFF
--- a/docs/concepts/accounts.md
+++ b/docs/concepts/accounts.md
@@ -1,7 +1,6 @@
 ---
 title: Accounts
 description: How accounts are organized in Defang.
-sidebar_position: 100
 ---
 
 # Accounts

--- a/docs/concepts/authentication.md
+++ b/docs/concepts/authentication.md
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 200
 title: Authentication
 description: Authenticating with Defang.
 ---

--- a/docs/concepts/compose.md
+++ b/docs/concepts/compose.md
@@ -1,7 +1,6 @@
 ---
 title: Compose
 description: Defang allows you to use the compose.yaml specification to deploy your application to the cloud.
-sidebar_position: 150
 ---
 
 # Compose

--- a/docs/concepts/configuration.md
+++ b/docs/concepts/configuration.md
@@ -1,7 +1,6 @@
 ---
 title: Configuration
 description: Configuring your Defang application, including sensitive config values like API keys, passwords, and other credentials.
-sidebar_position: 225
 ---
 
 # Configuration
@@ -67,7 +66,7 @@ In the example above, if we assume the value of the configuration variable ***US
 
 During `defang compose up` all variable references will be replaced with the actual value and made available in the container. If any referenced variable is not found the `defang compose up` command will be canceled.
 
-## Using Config with Pulumi 
+## Using Config with Pulumi
 In Defang, using config with [Pulumi](./pulumi.md) gives you the advantage of being able to manage your environment variables across different environments using Pulumi stacks.
 
 :::tip

--- a/docs/concepts/debug.md
+++ b/docs/concepts/debug.md
@@ -1,7 +1,6 @@
 ---
 title: Debug
 description: Defang uses AI to help you debug your cloud applications.
-sidebar_position: 650
 ---
 
 # Debug
@@ -16,20 +15,20 @@ Defang has another AI-driven tool called [`generate`](/docs/concepts/generate).
 
 Here is a typical workflow in the [Defang CLI](/docs/getting-started) that will automatically run the AI debugger tool:
 
-1. When you deploy a project with Defang (i.e. `defang compose up`), the CLI will wait for all services' statuses to switch to healthy. 
+1. When you deploy a project with Defang (i.e. `defang compose up`), the CLI will wait for all services' statuses to switch to healthy.
 
 2. If any service fails to deploy, the AI debugger will kick in and ask for permission.
 
 3. The AI agent will analyze the logs and files in your project to identify the issue(s).
 
-4. Then, it will provide you with the suggested fix(es) in the terminal. 
+4. Then, it will provide you with the suggested fix(es) in the terminal.
 
 :::tip
 The AI debugger will not change your files. Instead, it will show you a suggestion, and it is up to you if you want to use it in your code.
 :::
 
-The AI debugger only kicks in when any service in a project fails to deploy. This could be because of a build failure, healthchecks failing, or a variety of other issues. 
+The AI debugger only kicks in when any service in a project fails to deploy. This could be because of a build failure, healthchecks failing, or a variety of other issues.
 
 :::info
-The AI debugger only kicks in when any service in a project fails to deploy. At the moment, we do not offer any way to trigger the AI debugger manually. 
+The AI debugger only kicks in when any service in a project fails to deploy. At the moment, we do not offer any way to trigger the AI debugger manually.
 :::

--- a/docs/concepts/defang-byoc.md
+++ b/docs/concepts/defang-byoc.md
@@ -1,7 +1,6 @@
 ---
 title: Defang BYOC
 description: Defang allows you deploy services, defined as containers, to your own cloud accounts.
-sidebar_position: 50
 ---
 
 # Defang BYOC

--- a/docs/concepts/defang-playground.md
+++ b/docs/concepts/defang-playground.md
@@ -1,7 +1,6 @@
 ---
 title: Defang Playground
 description: Defang Playground allows you to get a feel for how Defang works without running production workloads in your own cloud accounts.
-sidebar_position: 00
 ---
 
 # Defang Playground

--- a/docs/concepts/deployment-modes.md
+++ b/docs/concepts/deployment-modes.md
@@ -1,7 +1,6 @@
 ---
 title: Deployment Modes
 description: Defang provides three deployment modes which allow you to balance cost and resiliency.
-sidebar_position: 501
 ---
 
 # Deployment Modes

--- a/docs/concepts/deployments.md
+++ b/docs/concepts/deployments.md
@@ -1,7 +1,6 @@
 ---
 title: Deployment
 description: Defang will build your services in the cloud and manage the deployment process for you.
-sidebar_position: 500
 ---
 
 # Deployment

--- a/docs/concepts/domains.mdx
+++ b/docs/concepts/domains.mdx
@@ -1,22 +1,21 @@
 ---
-title: Domains    
+title: Domains
 description: Defang helps you provision SSL certificates and expose your services to the internet.
-sidebar_position: 280
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 # Domains
 
-Defang helps you provision SSL certificates and expose your services to the internet. You can expose your services using Defang-hosted domains or bring your own custom domain with [Defang BYOC](./defang-byoc.md). This page explains how to configure your services to be accessible from the public internet. 
+Defang helps you provision SSL certificates and expose your services to the internet. You can expose your services using Defang-hosted domains or bring your own custom domain with [Defang BYOC](./defang-byoc.md). This page explains how to configure your services to be accessible from the public internet.
 
 ## Defang-hosted Domains
 
-To make your service accessible from the public internet with Defang-hosted domains (under `defang.app`), you simply expose ports in your service definition. 
+To make your service accessible from the public internet with Defang-hosted domains (under `defang.app`), you simply expose ports in your service definition.
 
 ### Structure
 
-Defang-hosted domains use a structure that is based on your username and service name. 
+Defang-hosted domains use a structure that is based on your username and service name.
 
 <Tabs>
   <TabItem value="playground" label="Playground" default>
@@ -46,7 +45,7 @@ services:
         ports:
         // highlight-start
         - mode: ingress
-          target: 3000	
+          target: 3000
           protocol: http
         // highlight-end
 ```
@@ -103,7 +102,7 @@ services:
         ports:
         // highlight-start
         - mode: ingress
-          target: 3000	
+          target: 3000
           protocol: http
         // highlight-end
 ```

--- a/docs/concepts/estimation.md
+++ b/docs/concepts/estimation.md
@@ -1,7 +1,6 @@
 ---
 title: Cost Estimation
 description: Defang enables you to estimate the cost of deploying and running your project before you even create a cloud account.
-sidebar_position: 280
 ---
 
 # Cost Estimation

--- a/docs/concepts/generate.md
+++ b/docs/concepts/generate.md
@@ -1,7 +1,6 @@
 ---
 title: Generate
 description: Defang uses AI to help you generate a starting point for your cloud applications.
-sidebar_position: 100
 ---
 
 # Generate

--- a/docs/concepts/managed-llms/_category_.json
+++ b/docs/concepts/managed-llms/_category_.json
@@ -1,5 +1,4 @@
 {
   "label": "Managed LLMs",
-  "position": 425,
   "collapsible": true
 }

--- a/docs/concepts/managed-llms/managed-language-models.md
+++ b/docs/concepts/managed-llms/managed-language-models.md
@@ -1,7 +1,6 @@
 ---
 title: Using Managed LLMs
 description: Defang makes it easy to leverage cloud-native managed language models.
-sidebar_position: 3000
 ---
 
 # Managed Language Models

--- a/docs/concepts/managed-llms/openai-access-gateway.md
+++ b/docs/concepts/managed-llms/openai-access-gateway.md
@@ -1,7 +1,6 @@
 ---
 title: OpenAI Access Gateway
 description: Defang makes it easy to leverage cloud-native managed language models for your OpenAI-compatible application.
-sidebar_position: 3000
 ---
 
 # OpenAI Access Gateway

--- a/docs/concepts/managed-storage/_category_.json
+++ b/docs/concepts/managed-storage/_category_.json
@@ -1,5 +1,4 @@
 {
   "label": "Managed Storage",
-  "position": 450,
   "collapsible": true
 }

--- a/docs/concepts/managed-storage/managed-mongodb.md
+++ b/docs/concepts/managed-storage/managed-mongodb.md
@@ -1,7 +1,6 @@
 ---
 title: Managed MongoDB
 description: Defang can help you provision managed MongoDB instances.
-sidebar_position: 3000
 ---
 
 # Managed MongoDB

--- a/docs/concepts/managed-storage/managed-object-storage.md
+++ b/docs/concepts/managed-storage/managed-object-storage.md
@@ -1,7 +1,6 @@
 ---
 title: Managed Object Storage
 description: Defang can help you provision managed Redis instances.
-sidebar_position: 3000
 ---
 
 # Managed Object Storage

--- a/docs/concepts/managed-storage/managed-postgres.mdx
+++ b/docs/concepts/managed-storage/managed-postgres.mdx
@@ -1,7 +1,6 @@
 ---
 title: Managed Postgres
 description: Defang can help you provision managed Postgres.
-sidebar_position: 1000
 ---
 
 # Managed Postgres

--- a/docs/concepts/managed-storage/managed-redis.md
+++ b/docs/concepts/managed-storage/managed-redis.md
@@ -1,7 +1,6 @@
 ---
 title: Managed Redis
 description: Defang can help you provision managed Redis instances.
-sidebar_position: 2000
 ---
 
 # Managed Redis

--- a/docs/concepts/managed-storage/managed-storage.md
+++ b/docs/concepts/managed-storage/managed-storage.md
@@ -1,7 +1,6 @@
 ---
 title: Managed Storage
 description: Defang can help you provision managed storage services.
-sidebar_position: 000
 ---
 
 # Managed Storage

--- a/docs/concepts/networking.mdx
+++ b/docs/concepts/networking.mdx
@@ -1,7 +1,6 @@
 ---
 title: Networking
 description: Defang helps you safely configure your services' networking.
-sidebar_position: 300
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';

--- a/docs/concepts/observability.md
+++ b/docs/concepts/observability.md
@@ -1,7 +1,6 @@
 ---
 title: Observability
 description: Monitor and debug your Defang services with the Defang CLI and Portal.
-sidebar_position: 600
 ---
 
 # Observability
@@ -11,7 +10,7 @@ You can easily monitor and debug your Defang services at build and runtime using
 When you deploy a service using the `defang compose up`, the CLI will automatically start tailing the build and runtime logs for your service. You can also view the logs for your service in the Portal, or by using the `defang tail` command.
 
 :::tip
-Defang has a tutorial on how you can [monitor your services' status and logs](/docs/tutorials/monitoring-your-services). 
+Defang has a tutorial on how you can [monitor your services' status and logs](/docs/tutorials/monitoring-your-services).
 :::
 
 :::warning

--- a/docs/concepts/portal.md
+++ b/docs/concepts/portal.md
@@ -1,7 +1,6 @@
 ---
 title: Portal
 description: You can log into the Defang Portal to view the state of your Defang services.
-sidebar_position: 700
 ---
 
 # Portal
@@ -11,7 +10,7 @@ You can log into the Defang Portal at [portal.defang.dev](https://portal.defang.
 You can use the Portal to get an overview of your [services](/docs/concepts/services), view the logs for each service, quickly access exposed ports, view environment variables, and more.
 
 :::info
-The Defang Portal displays services deployed to Defang Playground. 
+The Defang Portal displays services deployed to Defang Playground.
 To view services deployed to Defang BYOC, please check out [Monitoring Your Services](/docs/tutorials/monitoring-your-services).
 :::
 

--- a/docs/concepts/projects.md
+++ b/docs/concepts/projects.md
@@ -1,7 +1,6 @@
 ---
 title: Projects
 description: A _project_ refers to a cohesive collection of services which are defined and managed using a `compose.yml` file.
-sidebar_position: 200
 ---
 
 # Projects

--- a/docs/concepts/pulumi.md
+++ b/docs/concepts/pulumi.md
@@ -1,7 +1,6 @@
 ---
 title: Pulumi
 description: Define your Defang services with Pulumi to integrate with other cloud resources.
-sidebar_position: 175
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/concepts/railpack.md
+++ b/docs/concepts/railpack.md
@@ -1,7 +1,6 @@
 ---
 title: Railpack
 description: Defang will use Railpack to make an OCI-Compliant container image for your project.
-sidebar_position: 500
 ---
 
 # Railpack

--- a/docs/concepts/resources.md
+++ b/docs/concepts/resources.md
@@ -1,7 +1,6 @@
 ---
 title: Resources
 description: Customize the resources your Defang services use.
-sidebar_position: 350
 ---
 
 # Run-time Resources

--- a/docs/concepts/scaling.md
+++ b/docs/concepts/scaling.md
@@ -1,7 +1,6 @@
 ---
 title: Scaling
 description: Defang can help you handle service irregular loads.
-sidebar_position: 375
 ---
 
 # Scaling
@@ -47,10 +46,10 @@ With Defang, users on the Pro plan or higher can enable service-level autoscalin
 services:
   service-example:
     x-defang-autoscaling: true #enable autoscaling for this service
-    build: 
+    build:
        context: .
        dockerfile: Dockerfile
-    ports: 
+    ports:
         - mode: ingress
         target: 8080
         published: 8080
@@ -84,5 +83,5 @@ Auto-scaling systems typically rely on:
 
 - Ensure services are **stateless** or use **externalized state** (e.g., databases, caches) for smooth scaling. ([12 Factor App](https://12factor.net/processes))
 - Test services under load to identify scaling bottlenecks.
-  
+
 See Tutorial page [Scaling Tutorial](/docs/tutorials/scaling-your-services)

--- a/docs/concepts/security.md
+++ b/docs/concepts/security.md
@@ -1,7 +1,6 @@
 ---
-title: Security    
+title: Security
 description: Defang configures your cloud applications and services with security best practices.
-sidebar_position: 275
 ---
 
 # Security
@@ -20,7 +19,7 @@ Defang creates roles for your services to use, and attaches policies to those ro
 
 ## Networking
 
-Defang configures Security Groups, deploys applictions to a private subnet and uses an Application Load Balancer to route traffic to your services from the public internet only when required. 
+Defang configures Security Groups, deploys applictions to a private subnet and uses an Application Load Balancer to route traffic to your services from the public internet only when required.
 
 ## SSL
 

--- a/docs/concepts/services.md
+++ b/docs/concepts/services.md
@@ -1,7 +1,6 @@
 ---
 title: Services
 description: Defang allows you deploy services, defined as containers, to the cloud.
-sidebar_position: 200
 ---
 
 import Tabs from '@theme/Tabs';
@@ -45,21 +44,21 @@ We plan to add support for other types of services in the future, including serv
 
 ## Service Status
 
-An overview of the possible statuses for a service in Defang. 
+An overview of the possible statuses for a service in Defang.
 
 | Status | Details |
 |-|-|
-| BUILD_QUEUED | The service update has been received and is now in the queue for its image to be built. | 
-| BUILD_PROVISIONING | The container orchestrator is provisioning the necessary resources for building your service's image. | 
-| BUILD_PENDING | The necessary resources to build your service have been provisioned but the build has not yet been initiated. | 
-| BUILD_ACTIVATING | The container orchestrator is pulling the build container's image and creating the build container. | 
-| BUILD_RUNNING | The container which builds your service's image is successfully running. | 
-| BUILD_STOPPING | The container orchestrator has sent a termination signal to the build container and is waiting for the build process to stop. | 
-| BUILD_FAILED | The build container exited with a non-zero status code. | 
-| UPDATE_QUEUED | The service update has been received and is now in the queue. | 
-| SERVICE_DEPLOYMENT_PENDING | The necessary resources to run your service have been provisioned but the service has not yet been initiated. | 
-| SERVICE_DEPLOYMENT_COMPLETED | Your service has been deployed and is healthy. | 
-| SERVICE_DEPLOYMENT_FAILED | Your service could not be deployed. | 
+| BUILD_QUEUED | The service update has been received and is now in the queue for its image to be built. |
+| BUILD_PROVISIONING | The container orchestrator is provisioning the necessary resources for building your service's image. |
+| BUILD_PENDING | The necessary resources to build your service have been provisioned but the build has not yet been initiated. |
+| BUILD_ACTIVATING | The container orchestrator is pulling the build container's image and creating the build container. |
+| BUILD_RUNNING | The container which builds your service's image is successfully running. |
+| BUILD_STOPPING | The container orchestrator has sent a termination signal to the build container and is waiting for the build process to stop. |
+| BUILD_FAILED | The build container exited with a non-zero status code. |
+| UPDATE_QUEUED | The service update has been received and is now in the queue. |
+| SERVICE_DEPLOYMENT_PENDING | The necessary resources to run your service have been provisioned but the service has not yet been initiated. |
+| SERVICE_DEPLOYMENT_COMPLETED | Your service has been deployed and is healthy. |
+| SERVICE_DEPLOYMENT_FAILED | Your service could not be deployed. |
 
 :::tip
 You can run the `defang compose ps` command to view the status of your services.

--- a/docs/tutorials/adding-custom-one-click-deploy.md
+++ b/docs/tutorials/adding-custom-one-click-deploy.md
@@ -1,7 +1,6 @@
 ---
 title: Adding Custom 1-Click Deploy to Your App
-sidebar_position: 800
-description: Add a custom 1-Click Deploy link to deploy your own app. 
+description: Add a custom 1-Click Deploy link to deploy your own app.
 ---
 
 import { URLProvider, URLEncode } from "../../src/components/OneClick";
@@ -12,14 +11,14 @@ import { URLProvider, URLEncode } from "../../src/components/OneClick";
 
 This tutorial will show you how to add a 1-Click Deploy link so other people can easily deploy your app to the Defang Playground and eventually to their own cloud accounts.
 
-The link is often placed as a button in the `README.md` file of your project repository, and is the easiest way to allow anyone to deploy your app. 
+The link is often placed as a button in the `README.md` file of your project repository, and is the easiest way to allow anyone to deploy your app.
 
 :::info
-If you are trying to use 1-Click Deploy with one of our [samples](https://defang.io/samples/), we have a separate tutorial on [how to use 1-Click Deploy](/docs/tutorials/using-one-click-deploy). 
+If you are trying to use 1-Click Deploy with one of our [samples](https://defang.io/samples/), we have a separate tutorial on [how to use 1-Click Deploy](/docs/tutorials/using-one-click-deploy).
 :::
 
 ### How 1-Click Deploy Works
-A 1-Click Deploy link points to a special URL. Clicking this link will prompt the user to create a new GitHub repo with a clone of your project. This new repo will contain a GitHub Actions workflow which will automatically deploy the project to Defang. 
+A 1-Click Deploy link points to a special URL. Clicking this link will prompt the user to create a new GitHub repo with a clone of your project. This new repo will contain a GitHub Actions workflow which will automatically deploy the project to Defang.
 
 ## Pre-requisites
 
@@ -30,10 +29,10 @@ A 1-Click Deploy link points to a special URL. Clicking this link will prompt th
 You will need a `compose.yaml` file in the root folder of your project repository to describe the services which will be deployed. Learn more about writing [Compose files](/docs/concepts/compose#example-of-a-compose-file).
 
 ## Step 2 - Copy the GitHub Workflow
- 
-In your project, add a new folder named `.github`, then add a folder named `workflows` inside it, and copy the entire GitHub Workflow `deploy.yaml` file from [here](https://github.com/DefangLabs/samples/blob/main/starter-sample/.github/workflows/deploy.yaml) into the `workflows` folder. 
- 
-If your app requires [configuration](/docs/concepts/configuration) (e.g. API keys, passwords, etc.), learn more about [managing config variables with the Defang GitHub Action](https://github.com/DefangLabs/defang-github-action?tab=readme-ov-file#managing-config-values). 
+
+In your project, add a new folder named `.github`, then add a folder named `workflows` inside it, and copy the entire GitHub Workflow `deploy.yaml` file from [here](https://github.com/DefangLabs/samples/blob/main/starter-sample/.github/workflows/deploy.yaml) into the `workflows` folder.
+
+If your app requires [configuration](/docs/concepts/configuration) (e.g. API keys, passwords, etc.), learn more about [managing config variables with the Defang GitHub Action](https://github.com/DefangLabs/defang-github-action?tab=readme-ov-file#managing-config-values).
 
 You should have a `.yaml` file similar to the one below:
 ```yaml
@@ -63,7 +62,7 @@ jobs:
 ## Step 3 - Prepare Your Repository
 
 To support 1-Click Deploy, your repository must be a [Template Repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template). In order to make your repository into a Template Repository, complete the following steps:
-1. Go to the repository's "Settings" near the right on the top bar. 
+1. Go to the repository's "Settings" near the right on the top bar.
 2. Select the "Template repository" box to turn your repo into a template repo, as seen below:
 
 ![select-template-repo-box](/img/custom-one-click-tutorial/select-template-repo-box.png)
@@ -81,7 +80,7 @@ Now stay on this page and continue to the next step.
 
 ## Step 4 - Get the Encoded URL
 
-You will need the encoded version of the URL of the page from the previous step. This will be used as a redirect for the 1-Click Deploy link. 
+You will need the encoded version of the URL of the page from the previous step. This will be used as a redirect for the 1-Click Deploy link.
 
 1. Copy the URL of the page you are on ( "Create a new repository" page sourced from your template repository). It should look something like the following:
 ```
@@ -99,7 +98,7 @@ You can just paste your url in here to get the encoded version:
 
 ## Step 5 - Create the 1-Click Deploy Link
 
-You will need to create a 1-Click Deploy link with the following format: `https://portal.defang.dev/redirect?url=` + your encoded URL. This ensures that the user can get [logged in](/docs/concepts/authentication/) to Defang before they get redirected to clone your app for deployment. 
+You will need to create a 1-Click Deploy link with the following format: `https://portal.defang.dev/redirect?url=` + your encoded URL. This ensures that the user can get [logged in](/docs/concepts/authentication/) to Defang before they get redirected to clone your app for deployment.
 
 :::tip
 Optionally, you can add `&name=<your-suggested-name>` to the end of the link if you'd like to suggest a name for the user to use for their deployment.
@@ -110,7 +109,7 @@ The finished link should look similar to the one below:
 https://portal.defang.dev/redirect?url=https%3A%2F%2Fgithub.com%2Fnew%3Ftemplate_name%3D<your-repo-name>%26template_owner%3D<your-github-username>&name=<your-suggested-name>
 ```
 
-Now you have a link for anyone to deploy your app to Defang, with just 1 click. 
+Now you have a link for anyone to deploy your app to Defang, with just 1 click.
 
 ## Step 6 - Use the Link
 For example, you can add it as a link in a Markdown file:

--- a/docs/tutorials/configure-environment-variables.md
+++ b/docs/tutorials/configure-environment-variables.md
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 400
 title: Configure Environment Variables
 description: How to configure sensitive environment variables in Defang.
 ---
@@ -15,11 +14,11 @@ This tutorial will show you how to configure sensitive environment variables in 
 * [The Defang CLI](/docs/getting-started#install-the-defang-cli)
 
 ## Step 1 - Go to your `compose.yaml` file
-:::info 
+:::info
 If you are using [Pulumi](/docs/concepts/pulumi) instead of Compose files to define your services, please see [Using Config With Pulumi](/docs/concepts/configuration#using-config-with-pulumi) instead.
 :::
 
-In your Compose file, you can define a sensitive config variable for your service by leaving it as a **blank or `null` value**. Defang will recognize it as a sensitive value. 
+In your Compose file, you can define a sensitive config variable for your service by leaving it as a **blank or `null` value**. Defang will recognize it as a sensitive value.
 
 In the example below, let's define `API_KEY` as an environment variable.
 
@@ -45,7 +44,7 @@ To store the actual (sensitive) value of the variable, open up a terminal and ty
 ```bash
 defang config set API_KEY=actualvalue
 ```
-Remember to replace `API_KEY` with your variable name and `actualvalue` with your actual value. 
+Remember to replace `API_KEY` with your variable name and `actualvalue` with your actual value.
 
 :::tip
 You can view all the config variables you are storing in Defang by doing: `defang config ls`.

--- a/docs/tutorials/deploy-container-using-the-cli.mdx
+++ b/docs/tutorials/deploy-container-using-the-cli.mdx
@@ -1,13 +1,12 @@
 ---
 title: Deploy Existing Containers
-sidebar_position: 200
 ---
 
 # Deploy Existing Containers
 
-This tutorial will show you how to deploy an existing container/multi-container application using Defang. 
+This tutorial will show you how to deploy an existing container/multi-container application using Defang.
 
-This is rather useful if you already have a Docker container built manually, or through a CI/CD system (where the resulting image is available in a public or private repository accessible by Defang), but it is not required in order to follow along. 
+This is rather useful if you already have a Docker container built manually, or through a CI/CD system (where the resulting image is available in a public or private repository accessible by Defang), but it is not required in order to follow along.
 
 ## Step 1 - Make a Docker Compose file
 :::tip
@@ -15,7 +14,7 @@ If you are unfamiliar with Docker Compose files, check out the [Compose](/docs/c
 :::
 Create a `compose.yaml` file to define the [service(s)](/docs/concepts/services) in your application.
 
-If you already have a Docker Compose file to define your service(s), you can use it directly and skip this step. 
+If you already have a Docker Compose file to define your service(s), you can use it directly and skip this step.
 
 
 ```yaml
@@ -24,14 +23,14 @@ services:
     image: nginx:latest
     ports:
       - mode: ingress
-        target: 3000		
+        target: 3000
   app:
     build:
       context: .
       dockerfile: Dockerfile
     ports:
       - mode: ingress
-        target: 4000	
+        target: 4000
   redis:
     image: redis:6.2
     restart: unless-stopped
@@ -48,4 +47,4 @@ Run the following command in the [Defang CLI](/docs/getting-started#install-the-
 ```text
 defang compose up
 ```
-    
+

--- a/docs/tutorials/deploy-openai-apps/aws-bedrock.mdx
+++ b/docs/tutorials/deploy-openai-apps/aws-bedrock.mdx
@@ -1,6 +1,5 @@
 ---
 title: AWS Bedrock
-sidebar_position: 50
 description: Deploy OpenAI Apps to AWS Bedrock using Defang.
 ---
 import React from 'react';
@@ -8,7 +7,7 @@ import {useColorMode} from '@docusaurus/theme-common';
 
 # Deploy OpenAI Apps to AWS Bedrock
 
-Let's assume you have an app that uses an OpenAI client library and you want to deploy it to the cloud on **AWS Bedrock**.  
+Let's assume you have an app that uses an OpenAI client library and you want to deploy it to the cloud on **AWS Bedrock**.
 
 This tutorial shows you how **Defang** makes it easy.
 :::info
@@ -59,7 +58,7 @@ You can use AWS Bedrock without changing your `app` code by introducing a new [`
 :::tip
 **OpenAI Key**
 
-You no longer need your original OpenAI API Key.  
+You no longer need your original OpenAI API Key.
 We recommend generating a random secret for authentication with the gateway:
 
 ```bash

--- a/docs/tutorials/deploy-openai-apps/deploy-openai-apps.mdx
+++ b/docs/tutorials/deploy-openai-apps/deploy-openai-apps.mdx
@@ -1,6 +1,5 @@
 ---
 title: Deploy OpenAI Apps on Managed LLMs
-sidebar_position: 45
 description: Deploy OpenAI Apps on Managed LLMs
 ---
 

--- a/docs/tutorials/deploy-openai-apps/gcp-vertex.mdx
+++ b/docs/tutorials/deploy-openai-apps/gcp-vertex.mdx
@@ -1,6 +1,5 @@
 ---
 title: GCP Vertex AI
-sidebar_position: 50
 description: Deploy OpenAI Apps to GCP Vertex AI using Defang.
 ---
 import React from 'react';
@@ -61,7 +60,7 @@ You can use Vertex AI without changing your `app` code by introducing a new [`de
 :::tip
 **OpenAI Key**
 
-You no longer need your original OpenAI API Key.  
+You no longer need your original OpenAI API Key.
 We recommend generating a random secret for authentication with the gateway:
 
 ```bash
@@ -110,7 +109,7 @@ You should configure your application to specify the model you want to use.
 
 Choose the correct `MODEL` depending on which cloud provider you are using.
 
-Ensure you have the necessary permissions to access the model you intend to use. 
+Ensure you have the necessary permissions to access the model you intend to use.
 To do this, you can check your [AWS Bedrock model access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html) or [GCP Vertex AI model access](https://cloud.google.com/vertex-ai/generative-ai/docs/control-model-access).
 
 :::info

--- a/docs/tutorials/deploy-to-aws.mdx
+++ b/docs/tutorials/deploy-to-aws.mdx
@@ -1,7 +1,6 @@
 ---
 title: Deploy to AWS
 description: Defang allows you deploy to your own Amazon Web Services (AWS) account.
-sidebar_position: 11
 ---
 
 # Deploy to Amazon Web Services (AWS)

--- a/docs/tutorials/deploy-to-digitalocean.mdx
+++ b/docs/tutorials/deploy-to-digitalocean.mdx
@@ -1,7 +1,6 @@
 ---
 title: Deploy to DigitalOcean
 description: Defang allows you deploy to your own DigitalOcean account.
-sidebar_position: 11
 ---
 
 # Deploy to DigitalOcean
@@ -31,7 +30,7 @@ Defang will look for your DigitalOcean credentials in your shell environment and
 
 :::tip
 You can find your DigitalOcean token in the [API section](https://cloud.digitalocean.com/account/api/tokens) and
-your Spaces Access Keys in the [Spaces Object Storage section](https://cloud.digitalocean.com/spaces) 
+your Spaces Access Keys in the [Spaces Object Storage section](https://cloud.digitalocean.com/spaces)
 in the DigitalOcean Control Panel.
 :::
 

--- a/docs/tutorials/deploy-to-gcp.mdx
+++ b/docs/tutorials/deploy-to-gcp.mdx
@@ -1,7 +1,6 @@
 ---
 title: Deploy to GCP
 description: Defang allows you deploy to your own Google Cloud Platform (GCP) account.
-sidebar_position: 11
 ---
 
 # Deploy to Google Cloud Platform (GCP)

--- a/docs/tutorials/deploy-to-playground.mdx
+++ b/docs/tutorials/deploy-to-playground.mdx
@@ -1,7 +1,6 @@
 ---
 title: Deploy to Playground
 description: Deploy to the free Defang Playground.
-sidebar_position: 15
 ---
 
 # Deploy to Playground

--- a/docs/tutorials/deploy-to-your-cloud.mdx
+++ b/docs/tutorials/deploy-to-your-cloud.mdx
@@ -1,10 +1,9 @@
 ---
 title: Deploy to Your Own Cloud
 description: Defang allows you deploy to your own cloud account.
-sidebar_position: 10
 ---
 
-# Deploy to Your Own Cloud 
+# Deploy to Your Own Cloud
 
 This tutorial will show you how to deploy your services to your own cloud account using Defang.
 
@@ -13,7 +12,7 @@ Defang makes it easier to deploy to any cloud—in your *own* cloud accounts. We
 If you aren't ready to deploy to your own cloud account, you can use the [Defang Playground](/docs/concepts/defang-playground) to get a feel for how Defang works for free.
 :::
 
-## Choose your cloud 
+## Choose your cloud
 
 A good starting point is to choose which cloud provider you want to deploy to. Defang supports the following cloud providers:
 

--- a/docs/tutorials/deploy-using-pulumi.mdx
+++ b/docs/tutorials/deploy-using-pulumi.mdx
@@ -1,6 +1,5 @@
 ---
 title: Deploy Using Pulumi
-sidebar_position: 400
 ---
 
 # Deploy Using Pulumi

--- a/docs/tutorials/deploy-with-gpu.mdx
+++ b/docs/tutorials/deploy-with-gpu.mdx
@@ -1,6 +1,5 @@
 ---
 title: Deploy a GPU-Powered Application
-sidebar_position: 500
 ---
 
 # Deploy a GPU-Powered Application to AWS

--- a/docs/tutorials/estimating-aws-deployment-costs.md
+++ b/docs/tutorials/estimating-aws-deployment-costs.md
@@ -1,7 +1,6 @@
 ---
 title: Estimating AWS Deployment Costs
 description: Defang enables you to estimate the cost of deploying and running your project before you even create a cloud account.
-sidebar_position: 280
 ---
 
 # Estimating AWS Deployment Costs

--- a/docs/tutorials/estimating-gcp-deployment-costs.md
+++ b/docs/tutorials/estimating-gcp-deployment-costs.md
@@ -1,7 +1,6 @@
 ---
 title: Estimating GCP Deployment Costs
 description: Defang enables you to estimate the cost of deploying and running your project before you even create a cloud account.
-sidebar_position: 281
 ---
 
 # Estimating GCP Deployment Costs

--- a/docs/tutorials/generate-new-code-using-ai.mdx
+++ b/docs/tutorials/generate-new-code-using-ai.mdx
@@ -1,15 +1,14 @@
 ---
 title: Generate Project Outlines With AI
-sidebar_position: 50
 ---
 
 # Generate Project Outlines With AI
 
-This tutorial will show you how to use Defang's AI agent to [generate](/docs/concepts/generate) a project outline, and then deploy that project to the cloud using Defang. 
+This tutorial will show you how to use Defang's AI agent to [generate](/docs/concepts/generate) a project outline, and then deploy that project to the cloud using Defang.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/afglsBYieuc?si=GCvHhBu3H9ktMDHA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
-## Step 1 - Use the `defang generate` command in the CLI 
+## Step 1 - Use the `defang generate` command in the CLI
 
 Here you can describe what you would like the service to do and the [CLI](/docs/getting-started#install-the-defang-cli) will then [generate](/docs/concepts/generate) a project outline with all the files required to make it deployable with Defang.
 
@@ -28,7 +27,7 @@ defang generate
 ? Choose a sample service:
 Generate with AI
 
-? Please describe the service you'd like to build: [? for help] 
+? Please describe the service you'd like to build: [? for help]
 A basic service with 2 REST endpoints. The default endpoint will be for health check and should return a JSON object like this: { "status": "OK" }. The /echo endpoint will echo back all request parameters in the response.
 
 ? What folder would you like to create the service in? [? for help] (service1)

--- a/docs/tutorials/migrating-from-heroku.md
+++ b/docs/tutorials/migrating-from-heroku.md
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 100
 description: Deploy your Heroku Applications in your own Cloud Account with Defang
 ---
 

--- a/docs/tutorials/monitoring-your-services.md
+++ b/docs/tutorials/monitoring-your-services.md
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 400
 title: Monitoring Your Services
 description: How to monitor services deployed with Defang
 ---

--- a/docs/tutorials/scaling-your-services.mdx
+++ b/docs/tutorials/scaling-your-services.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 550
 title: Scaling Your Services
 description: How to scale services deployed with Defang
 ---

--- a/docs/tutorials/setting_up_your_gcp_account.md
+++ b/docs/tutorials/setting_up_your_gcp_account.md
@@ -1,6 +1,5 @@
 ---
 title: Setting Up Your GCP Account
-sidebar_position: 0
 description: Follow these steps to set up your Google Cloud Platform (GCP) account for deploying applications with Defang.
 ---
 

--- a/docs/tutorials/updating-your-services.md
+++ b/docs/tutorials/updating-your-services.md
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 500
 title: Updating Your Services
 description: How to update services deployed with Defang
 ---

--- a/docs/tutorials/use-your-own-domain-name.mdx
+++ b/docs/tutorials/use-your-own-domain-name.mdx
@@ -1,6 +1,5 @@
 ---
 title: How to Use Your Own Domain
-sidebar_position: 600
 ---
 
 # How to Use Your Own Domain With AWS

--- a/docs/tutorials/using-codespaces-gitpod.md
+++ b/docs/tutorials/using-codespaces-gitpod.md
@@ -1,6 +1,5 @@
 ---
 title: Using Codespaces and Gitpod
-sidebar_position: 700
 ---
 
 # Using Codespaces and Gitpod

--- a/docs/tutorials/using-one-click-deploy.md
+++ b/docs/tutorials/using-one-click-deploy.md
@@ -1,14 +1,13 @@
 ---
 title: Using 1-Click Deploy
-sidebar_position: 300
-description: Use 1-Click Deploy to easily deploy a sample to the Defang Playground. 
+description: Use 1-Click Deploy to easily deploy a sample to the Defang Playground.
 ---
 
 # Using 1-Click Deploy
 
-This tutorial will show you how to use Defang 1-Click Deploy to deploy a sample to the Defang Playground. 
+This tutorial will show you how to use Defang 1-Click Deploy to deploy a sample to the Defang Playground.
 
-The 1-Click Deploy button is the easiest way for new users to deploy a sample project to the [Defang Playground](/docs/concepts/defang-playground). No CLI installation is required. 
+The 1-Click Deploy button is the easiest way for new users to deploy a sample project to the [Defang Playground](/docs/concepts/defang-playground). No CLI installation is required.
 
 :::info
 To access the full range of features provided by Defang, we recommend using the [Defang CLI](/docs/getting-started).
@@ -21,7 +20,7 @@ Head to our [list of samples](https://defang.io/#samples) and click a sample you
 <br/>
 
 :::info
-Alternatively, you can find the "1-Click Deploy" button located in the `README.md` file of each sample's GitHub repository. 
+Alternatively, you can find the "1-Click Deploy" button located in the `README.md` file of each sample's GitHub repository.
 
 <img src="/img/use-one-click-tutorial/deploy-with-defang-button.png" alt="deploy-with-defang-button" width="400"/>
 <br/>
@@ -36,7 +35,7 @@ For 1-click deployments to work, Defang must have your permission, which you can
 
 ## Step 3 - Create Your Repo
 
-Once logged in, you'll be redirected to GitHub. Click the "Create repository button" to create a new repository with the sample project. 
+Once logged in, you'll be redirected to GitHub. Click the "Create repository button" to create a new repository with the sample project.
 
 <img src="/img/use-one-click-tutorial/create-repository.png" alt="create-repository" width="600"/>
 <br/>
@@ -44,7 +43,7 @@ Once logged in, you'll be redirected to GitHub. Click the "Create repository but
 
 ## Step 4 - Wait for Deployment to Complete
 
-A Github Action workflow will automatically start running to install Defang and deploy the sample to the Defang Playground. You can see this by going into the "Actions" tab in your GitHub repository. 
+A Github Action workflow will automatically start running to install Defang and deploy the sample to the Defang Playground. You can see this by going into the "Actions" tab in your GitHub repository.
 
 You can view the status of your deployment in the [Defang Portal](https://portal.defang.dev/), or by downloading the [Defang CLI](/docs/getting-started).  You can also see deployment progress in the "Actions" tab of your GitHub repository:
 


### PR DESCRIPTION
I think alphabetizing these sidebar items makes it easier to scan the sidebar. I don't think this is enough to solve our documentation organization problem, but I do think this is a small improvement.

<img width="273" height="801" alt="Screenshot 2025-09-08 at 16 23 26" src="https://github.com/user-attachments/assets/39907938-6de6-4711-8120-2b60dfc6eaf7" />
<img width="281" height="801" alt="Screenshot 2025-09-08 at 16 23 36" src="https://github.com/user-attachments/assets/d5c117de-e233-4edb-9040-c6c1aa3b658a" />
