### PR TITLE
note ssl connection error and solution in managed postgres docs

### DIFF
--- a/docs/concepts/managed-storage/managed-postgres.mdx
+++ b/docs/concepts/managed-storage/managed-postgres.mdx
@@ -39,7 +39,7 @@ You can connect to the managed Postgres instance using the name of your service 
 
 #### SSL
 
-By default, Defang configures managed Postgres instances to require SSL connections. To connect to the database, you will need to use a connection string that includes `sslmode=require`.
+In BYOC, Defang configures managed Postgres instances to require SSL connections. To connect to the database, you will need to use a connection string that includes `sslmode=require`.
 
 If your application does not connect using SSL, you will see an error message like the following:
 


### PR DESCRIPTION
Adding a note about solving the postgres `no encryption` error to the docs so users (and the debugger) can find it