### PR TITLE
add /docs/faq redirect for old clis

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -1,5 +1,9 @@
 [
   {
+    "from": "/docs/faq",
+    "to": "/docs/intro/faq/questions"
+  },
+  {
     "from": "/docs/faq/questions",
     "to": "/docs/intro/faq/questions"
   },


### PR DESCRIPTION
Linda reported that older versions of the CLI still print the `/docs/faq` url, and it looks like we forgot to add a redirect in ae4bbd2ec4954a23aadf68473c2e4eddb1cd53aa.