### PR TITLE
bedrock model access has been retired

### DIFF
--- a/docs/concepts/managed-llms/managed-language-models.md
+++ b/docs/concepts/managed-llms/managed-language-models.md
@@ -23,9 +23,7 @@ In order to leverage cloud-native managed language models from your Defang servi
 ## Example
 
 :::info
-Ensure you have enabled model access for the model you intend to use:
-* [Configure AWS Bedrock model access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html)
-* [Configure GCP Vertex AI model access](https://cloud.google.com/vertex-ai/generative-ai/docs/control-model-access)
+If you are planning to use Google Vertex AI, you must [enable model access](https://cloud.google.com/vertex-ai/generative-ai/docs/control-model-access) for each model you intend to use. This is not necessary on AWS Bedrock.
 :::
 
 Assume you have a web service like the following, which uses the cloud native SDK, for example:

--- a/docs/tutorials/deploy-openai-apps/aws-bedrock.mdx
+++ b/docs/tutorials/deploy-openai-apps/aws-bedrock.mdx
@@ -10,9 +10,6 @@ import {useColorMode} from '@docusaurus/theme-common';
 Let's assume you have an app that uses an OpenAI client library and you want to deploy it to the cloud on **AWS Bedrock**.
 
 This tutorial shows you how **Defang** makes it easy.
-:::info
-You must [configure AWS Bedrock model access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html) for each model you intend to use in your AWS account.
-:::
 
 Suppose you start with a `compose.yaml` file with one `app` service, like this:
 

--- a/docs/tutorials/deploy-openai-apps/gcp-vertex.mdx
+++ b/docs/tutorials/deploy-openai-apps/gcp-vertex.mdx
@@ -109,8 +109,7 @@ You should configure your application to specify the model you want to use.
 
 Choose the correct `MODEL` depending on which cloud provider you are using.
 
-Ensure you have the necessary permissions to access the model you intend to use.
-To do this, you can check your [AWS Bedrock model access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html) or [GCP Vertex AI model access](https://cloud.google.com/vertex-ai/generative-ai/docs/control-model-access).
+Ensure you have the necessary permissions to access the model you intend to use. To do this, you can check your [GCP Vertex AI model access](https://cloud.google.com/vertex-ai/generative-ai/docs/control-model-access).
 
 :::info
 **Choosing the Right Model**


### PR DESCRIPTION
AWS Bedrock has retired the "model access" requirement, so we can remove these notes from our docs:
https://console.aws.amazon.com/bedrock/home#/modelaccess

GCP still requires it