### PR TITLE
Update docs to deprecate playground : (

### DIFF
--- a/docs/concepts/accounts.md
+++ b/docs/concepts/accounts.md
@@ -7,7 +7,7 @@ description: How accounts are organized in Defang.
 
 Below, we will cover account creation with Defang, and how resources are organized within a cloud environment using your account info.
 
-Defang requires an account so we can organize your resources and provide you with a way to manage them. We also use your account to authenticate you when you interact with [Defang Playground](./defang-playground.md) and the [Defang Portal](./portal.md). Billing and payment information is also associated with your account.
+Defang requires an account so we can organize your resources and provide you with a way to manage them. We also use your account to authenticate you when you interact with the [Defang Portal](./portal.md). Billing and payment information is also associated with your account.
 
 ## Creating an Account
 

--- a/docs/concepts/configuration.md
+++ b/docs/concepts/configuration.md
@@ -107,7 +107,6 @@ Please note that while Defang supports setting sensitive config, it does not sup
 
 | Provider       | Config Support |
 |----------------|:--------------:|
-| Playground     |     ✅ |
 | AWS            |     ✅ |
 | DigitalOcean   |     ✅ |
 | GCP            |     ✅ |

--- a/docs/concepts/defang-byoc.md
+++ b/docs/concepts/defang-byoc.md
@@ -5,7 +5,7 @@ description: Defang allows you deploy services, defined as containers, to your o
 
 # Defang BYOC
 
-Defang aims to make it easier to deploy your services to the cloud. Specifically, Defang's goal is to make it easier to deploy your workloads to your *own* cloud accounts. We refer to this as bring-your-own-cloud (BYOC). We also provide Defang Playground, but it is only intended for non-production workloads so you can get a feel for how Defang works.
+Defang aims to make it easier to deploy your services to the cloud. Specifically, Defang's goal is to make it easier to deploy your workloads to your _own_ cloud accounts. We refer to this as bring-your-own-cloud (BYOC).
 
 Defang provisions and configures the necessary native managed services from your cloud provider to get your services up and running. For example, on AWS, Defang will configure an [ALB](https://aws.amazon.com/elasticloadbalancing/application-load-balancer/), set up [ECR](https://aws.amazon.com/ecr/), configure [CloudWatch](https://aws.amazon.com/cloudwatch/?nc2=type_a), and run your service on [ECS](https://aws.amazon.com/ecs/?nc2=type_a) and more. The following lists the existing and planned support for cloud providers.
 
@@ -19,8 +19,7 @@ Defang does run the Defang build service to build your container images, which t
 The Defang CLI can be configured to deploy to a cloud provider either by using the `--provider` flag or by setting the `DEFANG_PROVIDER` environment variable. For example:
 
 ```bash
-# Supported provider values: auto, aws, defang, digitalocean
-# Default is auto, which deploys to the Defang Playground but warns if it detects cloud credentials
+# Supported provider values: aws, defang, digitalocean
 $ defang compose up --provider=aws
 # or
 $ export DEFANG_PROVIDER=digitalocean

--- a/docs/concepts/defang-playground.md
+++ b/docs/concepts/defang-playground.md
@@ -3,6 +3,10 @@ title: Defang Playground
 description: Defang Playground allows you to get a feel for how Defang works without running production workloads in your own cloud accounts.
 ---
 
+:::danger Deprecation Notice
+Defang Playground has been deprecated and will be discontinued. New projects cannot be deployed to Playground. If you have existing projects on Playground, please migrate them to your own cloud account. See the [migration guide](/docs/tutorials/deploy-to-your-cloud) for instructions.
+:::
+
 # Defang Playground
 
 Defang aims to make it easier to deploy your services to the cloud. Specifically, Defang's goal is to make it easier to deploy your workloads to your *own* cloud accounts. We refer to this as bring-your-own-cloud (BYOC) which you can read about in more depth [here](./defang-byoc). We also provide Defang Playground, but it is only intended for non-production workloads so you can get a feel for how Defang works.

--- a/docs/concepts/deployments.md
+++ b/docs/concepts/deployments.md
@@ -5,7 +5,7 @@ description: Defang will build your services in the cloud and manage the deploym
 
 # Deployment
 
-When you deploy using Defang, whether it's with `defang compose up` with a [Compose file](./compose.md) or using a [Pulumi program](./pulumi.md), Defang will build your services in the cloud and manage the deployment process for you. If you provide a Dockerfile and build context, Defang will upload the files found within the build context to the cloud (either yours in [Defang BYOC](./defang-byoc.md) or ours in [Defang Playground](./defang-playground.md)), build the image, and store it in the cloud provider's container registry.
+When you deploy using Defang, whether it's with `defang compose up` with a [Compose file](./compose.md) or using a [Pulumi program](./pulumi.md), Defang will build your services in the cloud and manage the deployment process for you. If you provide a Dockerfile and build context, Defang will upload the files found within the build context to the cloud, build the image, and store it in the cloud provider's container registry.
 
 ## Deploying Updates
 
@@ -18,7 +18,7 @@ Defang can deploy your services using different [modes](/docs/concepts/deploymen
 By default, using the `affordable` mode, Defang will deprovision your existing services before provisioning replacements. This helps reduce costs.
 
 :::info
-In [Defang BYOC](./defang-byoc.md), Defang uses your cloud provider account to build and store your images. In [Defang Playground](./defang-playground.md), we build and store your images for you.
+In [Defang BYOC](./defang-byoc.md), Defang uses your cloud provider account to build and store your images.
 :::
 
 

--- a/docs/concepts/domains.mdx
+++ b/docs/concepts/domains.mdx
@@ -118,7 +118,6 @@ As of now, the Pulumi provider does not support [Defang BYOC](./defang-byoc.md) 
 
 | Provider | BYOD |
 | --- | --- |
-| [Playground](/docs/providers/playground) | ✅ no apex domains |
 | [AWS](/docs/providers/aws) | ✅ |
 | [DigitalOcean](/docs/providers/digitalocean) | ❌ |
 | [GCP](/docs/providers/gcp) | ✅ |

--- a/docs/concepts/estimation.md
+++ b/docs/concepts/estimation.md
@@ -67,7 +67,6 @@ defang compose up [--provider aws|gcp|digitalocean] [--mode affordable|balanced|
 
 | Provider       | Estimation Support |
 |----------------|:------------------:|
-| Playground     |     ❌ |
 | AWS            |     ✅ |
 | DigitalOcean   |     ❌ |
 | GCP            |     ✅ |

--- a/docs/concepts/managed-llms/managed-language-models.md
+++ b/docs/concepts/managed-llms/managed-language-models.md
@@ -11,7 +11,6 @@ Each cloud provider offers their own managed Large Language Model services. AWS 
 
 | Provider | Managed Language Models |
 | --- | --- |
-| [Playground](/docs/providers/playground#managed-llms) | ✅ |
 | [AWS Bedrock](/docs/providers/aws#managed-llms) | ✅ |
 | [DigitalOcean GenAI](/docs/providers/digitalocean#future-improvements) | ❌ |
 | [GCP Vertex AI](/docs/providers/gcp#managed-llms) | ✅ |
@@ -44,7 +43,4 @@ If you already have an OpenAI-compatible application, Defang makes it easy to de
 Defang has a [*Managed LLM sample*](https://github.com/DefangLabs/samples/tree/main/samples/managed-llm) that uses the OpenAI Access Gateway, and a [*Managed LLM with Docker Model Provider sample*](https://github.com/DefangLabs/samples/tree/main/samples/managed-llm-provider) that uses a Docker Model Provider.
 :::
 
-
-## Managed LLM on Playground
-If you are using the Managed LLM feature on [Defang Playground](/docs/concepts/defang-playground), please note that your `MODEL` (model ID) will be limited to a default model chosen by Defang.
-To access a full range of models, consider using [Defang BYOC](/docs/concepts/defang-byoc).
+$

--- a/docs/concepts/managed-llms/openai-access-gateway.md
+++ b/docs/concepts/managed-llms/openai-access-gateway.md
@@ -46,7 +46,6 @@ This can be configured through the following environment variables:
 
 | Provider | Managed Language Models |
 | --- | --- |
-| [Playground](/docs/providers/playground#managed-services) | ✅ |
 | [AWS Bedrock](/docs/providers/aws#managed-llms) | ✅ |
 | [DigitalOcean GenAI](/docs/providers/digitalocean#future-improvements) | ❌ |
 | [GCP Vertex AI](/docs/providers/gcp#managed-llms) | ✅ |

--- a/docs/concepts/managed-storage/managed-mongodb.md
+++ b/docs/concepts/managed-storage/managed-mongodb.md
@@ -15,7 +15,6 @@ Managed MongoDB is a service that allows you to store and retrieve large amounts
 
 | Provider | Managed MongoDB |
 | --- | --- |
-| [Playground](/docs/providers/playground#managed-services) | ⚠️ Unmanaged |
 | [AWS](/docs/providers/aws#managed-storage) | ✅ DocumentDB |
 | [DigitalOcean](/docs/providers/digitalocean#future-improvements) | ⚠️ Unmanaged |
 | [GCP](/docs/providers/gcp#future-improvements) | ✅ Firestore |

--- a/docs/concepts/managed-storage/managed-object-storage.md
+++ b/docs/concepts/managed-storage/managed-object-storage.md
@@ -15,7 +15,6 @@ Managed Object Storage, like AWS S3, is a service that allows you to store and r
 
 | Provider | Managed Object Storage |
 | --- | --- |
-| [Playground](/docs/providers/playground#managed-services) | ❌ |
 | [AWS](/docs/providers/aws#managed-storage) | ❌ |
 | [DigitalOcean](/docs/providers/digitalocean#future-improvements) | ❌ |
 | [GCP](/docs/providers/gcp#future-improvements) | ❌ |

--- a/docs/concepts/managed-storage/managed-postgres.mdx
+++ b/docs/concepts/managed-storage/managed-postgres.mdx
@@ -11,7 +11,6 @@ Postgres, or PostgreSQL, is a powerful open-source relational database system kn
 
 | Provider | Managed Postgres |
 | --- | --- |
-| [Playground](/docs/providers/playground#managed-services) | ⚠️ Unmanaged |
 | [AWS](/docs/providers/aws#managed-storage) | ✅ RDS Postgres |
 | [DigitalOcean](/docs/providers/digitalocean#future-improvements) | ⚠️ Unmanaged |
 | [GCP](/docs/providers/gcp#managed-storage) | ✅ Cloud SQL Postgres |

--- a/docs/concepts/managed-storage/managed-redis.md
+++ b/docs/concepts/managed-storage/managed-redis.md
@@ -11,7 +11,6 @@ Redis is an in-memory data structure store widely used for caching, real-time an
 
 | Provider | Managed Redis |
 | --- | --- |
-| [Playground](/docs/providers/playground#managed-services) | ⚠️ Unmanaged |
 | [AWS](/docs/providers/aws#managed-storage) | ✅ Elasticache |
 | [DigitalOcean](/docs/providers/digitalocean#future-improvements) | ⚠️ Unmanaged |
 | [GCP](/docs/providers/gcp#managed-redis) | ✅ Memorystore |

--- a/docs/concepts/observability.md
+++ b/docs/concepts/observability.md
@@ -13,10 +13,6 @@ When you deploy a service using the `defang compose up`, the CLI will automatica
 Defang has a tutorial on how you can [monitor your services' status and logs](/docs/tutorials/monitoring-your-services).
 :::
 
-:::warning
-Keep in mind that the [Defang Portal](./portal.md) only displays services deployed to Defang Playground.
-:::
-
 ## Tail
 
 The `defang tail` command will tail the logs for all your services by default. You can also specify a service `--name` to tail the logs for a specific service. If you specify the `--etag` the CLI will only tail the logs for a specific build of a service.

--- a/docs/concepts/one-off-jobs.md
+++ b/docs/concepts/one-off-jobs.md
@@ -137,7 +137,6 @@ One off jobs are deployed as temporary containers on the same infrastructure as 
 
 | Provider       | Release Task Support |
 |----------------|:--------------------:|
-| Playground     |     ✅ |
 | AWS            |     ✅ |
 | DigitalOcean   |     ❌ |
 | GCP            |     ✅ |

--- a/docs/concepts/portal.md
+++ b/docs/concepts/portal.md
@@ -5,7 +5,7 @@ description: You can log into the Defang Portal to view the state of your Defang
 
 # Portal
 
-You can log into the Defang Portal at [portal.defang.dev](https://portal.defang.dev) using your [Defang account](./accounts.md) to view the state of your Defang services.
+You can log into the Defang Portal at [portal.defang.io](https://portal.defang.io) using your [Defang account](./accounts.md) to view the state of your Defang services.
 
 You can use the Portal to get an overview of your [services](/docs/concepts/services), view the logs for each service, quickly access exposed ports, view environment variables, and more. The Portal is also where you manage your [workspaces](./workspaces.md), invite team members, and configure billing.
 

--- a/docs/concepts/portal.md
+++ b/docs/concepts/portal.md
@@ -5,12 +5,11 @@ description: You can log into the Defang Portal to view the state of your Defang
 
 # Portal
 
-You can log into the Defang Portal at [portal.defang.dev](https://portal.defang.dev) using your [Defang account](./accounts.md) to view the state of your Defang services running in the Defang Playground for non-production applications.
+You can log into the Defang Portal at [portal.defang.dev](https://portal.defang.dev) using your [Defang account](./accounts.md) to view the state of your Defang services.
 
 You can use the Portal to get an overview of your [services](/docs/concepts/services), view the logs for each service, quickly access exposed ports, view environment variables, and more. The Portal is also where you manage your [workspaces](./workspaces.md), invite team members, and configure billing.
 
 :::info
-The Defang Portal displays services deployed to Defang Playground.
 To view services deployed to Defang BYOC, please check out [Monitoring Your Services](/docs/tutorials/monitoring-your-services).
 :::
 

--- a/docs/concepts/railpack.md
+++ b/docs/concepts/railpack.md
@@ -148,7 +148,6 @@ services:
 
 | Provider       | Railpack Support |
 |----------------|:----------------:|
-| Playground     |     ✅ |
 | AWS            |     ✅ |
 | DigitalOcean   |     ❌ |
 | GCP            |     ✅ |

--- a/docs/concepts/scaling.md
+++ b/docs/concepts/scaling.md
@@ -68,7 +68,6 @@ Auto-scaling systems typically rely on:
 
 | Provider       | Auto-Scaling Support |
 |----------------|:--------------------:|
-| Playground     |     ❌ |
 | AWS            |     ✅ |
 | DigitalOcean   |     ❌ |
 | GCP            |     ✅ |

--- a/docs/intro/faq/questions.md
+++ b/docs/intro/faq/questions.md
@@ -11,7 +11,7 @@ import {Button, ButtonGroup, FormGroup, FormLabel} from "@mui/material"
 
 ### Which cloud/region is the app being deployed to?
 
-- In the [Defang Playground](/docs/concepts/defang-playground), the app is deployed to AWS `us-west-2`. In the [Defang BYOC](/docs/concepts/defang-byoc) model, the region is determined by your Defang BYOC [Provider](/docs/providers) settings.
+- In the [Defang BYOC](/docs/concepts/defang-byoc) model, the region is determined by your Defang BYOC [Provider](/docs/providers) settings.
 
 ### Can I bring my own AWS or other cloud account?
 
@@ -66,10 +66,10 @@ import {Button, ButtonGroup, FormGroup, FormLabel} from "@mui/material"
 ## Feature Comparisons
 
 ### Is Defang a run-time platform?
-- No. Defang is not a run-time platform. Instead, it lets you host and run your application on a [cloud provider](/docs/providers) of your choice. You can think of it as a tool that makes it way easier to deploy to that cloud provider. We do provide [Defang Playground](/docs/concepts/defang-playground), but it is meant to be used as a testing environment only.
+- No. Defang is not a run-time platform. Instead, it lets you host and run your application on a [cloud provider](/docs/providers) of your choice. You can think of it as a tool that makes it way easier to deploy to that cloud provider.
 
 ### What is the difference between Defang and platforms such as Vercel, fly.io, Railway, Render, or Heroku?
-- Defang is a tool that helps you get your application deployed to a [cloud provider](/docs/providers) of your choice, and it is not a platform. Unlike platforms, Defang does not host your application. We do provide [Defang Playground](/docs/concepts/defang-playground), but it is meant to be used as a testing environment only.
+- Defang is a tool that helps you get your application deployed to a [cloud provider](/docs/providers) of your choice, and it is not a platform. Unlike platforms, Defang does not host your application.
 
 ### What is the difference between Defang and tools such as SST?
 - Defang is cloud-agnostic and language-agnostic, meaning that it is designed to work with different [cloud providers](/docs/providers), and programming languages. Since Defang is not tied to just one cloud or language, this allows for greater flexibility in a wide range of cases. Another difference is that Defang follows the [Compose specification](https://docs.docker.com/compose/compose-file/), allowing it to work smoothly with various container platforms such as Docker.

--- a/docs/intro/intro.mdx
+++ b/docs/intro/intro.mdx
@@ -32,12 +32,6 @@ import DocCardList from "@docusaurus/theme-classic/lib/theme/DocCardList";
             },
             {
                 type: "link",
-                href: "/docs/tutorials/deploy-to-playground",
-                label: "Try Defang",
-                description: "Deploy to our free Playground",
-            },
-            {
-                type: "link",
                 href: "/docs/tutorials/deploy-to-your-cloud",
                 label: "Deploy to your own cloud",
                 description: "When you're ready for production",

--- a/docs/intro/what-is-defang.mdx
+++ b/docs/intro/what-is-defang.mdx
@@ -22,8 +22,7 @@ The [Defang CLI (command line interface)](/docs/intro/getting-started#install-th
 
 Defang can automatically build and deploy your project with a single command.
 
-    - If you’re new to Defang, you can try deploying to [Defang Playground](/docs/concepts/defang-playground.md), a hosted environment to learn to use Defang with non-production workloads.
-    - Once you’re ready, you can [deploy](/docs/tutorials/deploy-to-your-cloud) a project to your own cloud account - we call this [Defang BYOC (Bring-your-Own-Cloud)](/docs/concepts/defang-byoc.md). We offer support for the following cloud providers:
+    - Once you're ready, you can [deploy](/docs/tutorials/deploy-to-your-cloud) a project to your own cloud account - we call this [Defang BYOC (Bring-your-Own-Cloud)](/docs/concepts/defang-byoc.md). We offer support for the following cloud providers:
       * [Amazon Web Services (AWS)](/docs/tutorials/deploy-to-aws)
       * [DigitalOcean](/docs/tutorials/deploy-to-digitalocean)
       * [Google Cloud Platform (GCP)](/docs/tutorials/deploy-to-gcp)

--- a/docs/providers/playground.md
+++ b/docs/providers/playground.md
@@ -4,6 +4,10 @@ description: The Defang Playground is a free tier that allows you to experiment 
 sidebar_position: 10
 ---
 
+:::danger Deprecation Notice
+Defang Playground has been deprecated and will be discontinued. New projects cannot be deployed to Playground. If you have existing projects on Playground, please migrate them to your own cloud account. See the [migration guide](/docs/tutorials/deploy-to-your-cloud) for instructions.
+:::
+
 The Defang Playground is a free deployment provider that allows you to experiment with Defang. The Playground is a shared environment that should not be used to run production workloads. The Playground is a great way to get started with Defang. You can even use [1-Click Deploy](/docs/tutorials/using-one-click-deploy) to try it out quickly or you can get started with the [Defang CLI](/docs/intro/getting-started).
 
 This page highlights architectural considerations when deploying to the Playground and any differences you might encounter when deploying to the Playground versus deploying to your own cloud account.

--- a/docs/tutorials/deploy-to-playground.mdx
+++ b/docs/tutorials/deploy-to-playground.mdx
@@ -3,6 +3,10 @@ title: Deploy to Playground
 description: Deploy to the free Defang Playground.
 ---
 
+:::danger Deprecation Notice
+Defang Playground has been deprecated and will be discontinued. New projects cannot be deployed to Playground. Please [deploy to your own cloud account](/docs/tutorials/deploy-to-your-cloud) instead.
+:::
+
 # Deploy to Playground
 
 This tutorial will show you how to deploy your project to the free [Defang Playground](/docs/concepts/defang-playground).

--- a/docs/tutorials/deploy-to-your-cloud.mdx
+++ b/docs/tutorials/deploy-to-your-cloud.mdx
@@ -9,7 +9,6 @@ This tutorial will show you how to deploy your services to your own cloud accoun
 
 :::tip
 Defang makes it easier to deploy to any cloud—in your *own* cloud accounts. We refer to this as [bring-your-own-cloud (BYOC)](/docs/concepts/defang-byoc).
-If you aren't ready to deploy to your own cloud account, you can use the [Defang Playground](/docs/concepts/defang-playground) to get a feel for how Defang works for free.
 :::
 
 ## Choose your cloud

--- a/docs/tutorials/deploy-with-gpu.mdx
+++ b/docs/tutorials/deploy-with-gpu.mdx
@@ -9,7 +9,7 @@ This tutorial will show you how to create and deploy a GPU-powered application o
 We will walk you through the whole deployment process based on the [Mistral & vLLM](https://github.com/DefangLabs/samples/tree/main/samples/vllm) sample.
 
 :::info
-Note that GPU deployments are not permitted on the Defang Playground. You must [upgrade to a paid account](https://defang.io/pricing/) and [deploy to your own cloud account](/docs/tutorials/deploy-to-your-cloud).
+GPU deployments require a paid account. You must [upgrade to a paid account](https://defang.io/pricing/) and [deploy to your own cloud account](/docs/tutorials/deploy-to-your-cloud).
 :::
 
 <iframe

--- a/docs/tutorials/deploy-with-gpu.mdx
+++ b/docs/tutorials/deploy-with-gpu.mdx
@@ -8,10 +8,6 @@ This tutorial will show you how to create and deploy a GPU-powered application o
 
 We will walk you through the whole deployment process based on the [Mistral & vLLM](https://github.com/DefangLabs/samples/tree/main/samples/vllm) sample.
 
-:::info
-GPU deployments require a paid account. You must [upgrade to a paid account](https://defang.io/pricing/) and [deploy to your own cloud account](/docs/tutorials/deploy-to-your-cloud).
-:::
-
 <iframe
   width="560"
   height="315"

--- a/docs/tutorials/monitoring-your-services.md
+++ b/docs/tutorials/monitoring-your-services.md
@@ -9,13 +9,9 @@ This tutorial will show you how to monitor your service status and logs in Defan
 
 ## Status
 
-When deploying to Playground, you can monitor your service status from the [Defang Portal](https://portal.defang.dev).
-
 When deploying to your own cloud, the primary way to monitor your services is through your cloud provider's dashboard. However, Defang does provide some tools for monitoring your service logs.
 
 ## Logs
-
-When deploying to Playground, your service's logs may be viewed in the [Defang Portal](https://portal.defang.dev).
 
 By default when deploying, including to your own cloud, all output (stdout and stderr) from your app is logged and accessible via the [Defang CLI](/docs/intro/getting-started#install-the-defang-cli). You can view these logs in real-time or for a time in the past. You can view logs for all your services, one service, or even one specific deployment of a service.
 
@@ -47,5 +43,4 @@ All of the above flags can be combined to get the exact logs you need. See the C
 
 :::info
 * To learn more about observability in Defang, check out the [Observability page](../concepts/observability.md).
-* Note that the Defang Portal only displays services deployed to Defang Playground.
 :::


### PR DESCRIPTION
- Remove Playground from provider compatibility tables across documentation
- Add deprecation banners to Playground concept, provider, and tutorial pages
- Update intro and tutorial pages to remove Playground mentions
- Update FAQ to reference BYOC instead of Playground