### PR TITLE
docs: add Recipe concept and align how-it-works with BYOC CD task

### DIFF
--- a/docs/concepts/deployment-modes.md
+++ b/docs/concepts/deployment-modes.md
@@ -9,10 +9,14 @@ description: Deployment modes are Defang's built-in recipes; they are now part o
 Deployment modes are now part of the broader [Recipe](/docs/concepts/recipe) concept. See [Recipe](/docs/concepts/recipe) for the full details, including a comparison of what each built-in recipe configures.
 :::
 
-`affordable`, `balanced`, and `high_availability` are Defang's three built-in [recipes](/docs/concepts/recipe) — presets of infrastructure-as-code parameters that trade off cost against resiliency. You select one with the `--mode` CLI flag, which defaults to `affordable`:
+`affordable`, `balanced`, and `high_availability` are Defang's three built-in [recipes](/docs/concepts/recipe) — presets of infrastructure-as-code parameters that trade off cost against resiliency. You can select one with the `--mode` CLI flag, which defaults to `affordable`:
 
 ```bash
 defang compose up --mode=high_availability
 ```
+
+:::tip
+While the `--mode` flag still works, the recommended way to choose a mode is to configure a [stack](/docs/concepts/stacks), which records the provider, region, and mode for a deployment so you don't have to pass these flags on every command.
+:::
 
 Recipes generalize and supersede this fixed set of modes by letting you set the underlying infrastructure parameters directly. See the [Recipe](/docs/concepts/recipe) concept for more information.

--- a/docs/concepts/deployment-modes.md
+++ b/docs/concepts/deployment-modes.md
@@ -1,26 +1,18 @@
 ---
 title: Deployment Modes
-description: Defang provides three deployment modes which allow you to balance cost and resiliency.
+description: Deployment modes are Defang's built-in recipes; they are now part of the broader Recipe concept.
 ---
 
 # Deployment Modes
 
-Defang provides three deployment modes: `affordable`, `balanced`, and `high_availability`. These modes allow you to balance cost and resiliency according to your needs.
+:::info
+Deployment modes are now part of the broader [Recipe](/docs/concepts/recipe) concept. See [Recipe](/docs/concepts/recipe) for the full details, including a comparison of what each built-in recipe configures.
+:::
 
-* **Affordable**: This mode is used for development and testing purposes. It typically involves less stringent resource allocations and may include debugging tools and verbose logging to aid in development.
-* **Balanced**: This mode serves as a pre-production environment where applications are tested in conditions that closely mimic production. It helps in identifying issues that might not be apparent in the development environment.
-* **High Availability**: This mode is used for live deployments. It involves optimized configurations for performance, security, and reliability. Resource allocations are typically higher, and debugging tools are minimized to ensure stability.
+`affordable`, `balanced`, and `high_availability` are Defang's three built-in [recipes](/docs/concepts/recipe) — presets of infrastructure-as-code parameters that trade off cost against resiliency. You select one with the `--mode` CLI flag, which defaults to `affordable`:
 
-## Deployment Mode Comparison
+```bash
+defang compose up --mode=high_availability
+```
 
-| Feature | Affordable | Balanced | High Availability |
-|-|-|-|-|
-| Build Resources | Builds will be run with 2x vCPUs |  (like `affordable`) | Builds will be run with 4x vCPUs |
-| Compute | Using spot instances | (like `affordable`) | On-demand instances |
-| Databases | Defang will provision resources optimized for burstable memory | (like `high_availability`) | Defang will provision resources optimized for production |
-| Deployment | Previous deployments will be spun down before new deployments are spun up. Stopped tasks will not restart. | (like `high_availability`) | Rolling updates will be used to deploy new versions. Defang will gradually replace services while maintaining at least [the original number of replicas](/docs/tutorials/scaling-your-services). |
-| Logs | Logs retained for 1 day to save costs. | Logs retained for 7 days to balance cost and access. | Logs retained for 30 days for compliance. |
-| Networking | Only public IPs | Defang will provision a single NAT gateway | Defang will provision multiple NAT gateways. |
-| Load Balancing | HTTP redirect to HTTPS using `302 Found` | | Termination Protection will be enabled; logs are retained on "down" |
-| DNS | Defang will provision shorter TTLs; zones will be forcefully destroyed | | Defang will provision longer TTLs; records can be overwritten for ZDT |
-| Managed Storage | Operations that cause downtime are allowed | | Encryption at rest; Final snapshot created on "down" |
+Recipes generalize and supersede this fixed set of modes by letting you set the underlying infrastructure parameters directly. See the [Recipe](/docs/concepts/recipe) concept for more information.

--- a/docs/concepts/deployments.md
+++ b/docs/concepts/deployments.md
@@ -24,7 +24,7 @@ In [Defang BYOC](./defang-byoc.md), Defang uses your cloud provider account to b
 
 ### Deployment Modes
 
-As mentioned above, Defang offers different [deployment modes](/docs/concepts/deployment-modes): `affordable`, `balanced`, and `high_availability`. You can switch the modes using the `--mode` CLI flag.
+As mentioned above, Defang offers different [deployment modes](/docs/concepts/deployment-modes): `affordable`, `balanced`, and `high_availability`. You can switch the modes using the `--mode` CLI flag, though the recommended approach is to configure a [stack](/docs/concepts/stacks), which records the provider, region, and mode for a deployment.
 
 :::warning
 Workloads with GPUs do not support zero downtime deployments. If you have a workload with a GPU, you will experience downtime during updates.

--- a/docs/concepts/index.mdx
+++ b/docs/concepts/index.mdx
@@ -18,9 +18,9 @@ import DocCardList from "@docusaurus/theme-classic/lib/theme/DocCardList";
         },
         {
             type: "link",
-            href: "/docs/concepts/deployment-modes",
-            label: "Deployment Modes",
-            description: "Learn about the different Defang deployment modes",
+            href: "/docs/concepts/recipe",
+            label: "Recipes",
+            description: "Learn how recipes configure your cloud infrastructure beyond your Compose file",
         },
         {
             type: "link",

--- a/docs/concepts/recipe.md
+++ b/docs/concepts/recipe.md
@@ -1,0 +1,27 @@
+---
+title: Recipe
+description: A recipe holds the infrastructure-as-code parameters for a deployment that aren't derived from your Compose file.
+---
+
+# Recipe
+
+A _recipe_ is the set of infrastructure-as-code parameters that Defang applies to a deployment but that are **not** derived from your [Compose file(s)](./compose.md). Your Compose file describes _what_ your application is: its [services](/docs/concepts/services), images, ports, and environment. A recipe describes _how_ the surrounding cloud infrastructure should be provisioned: log retention, database tiers, availability zones, NAT gateways, deletion protection, health-check cadence, and similar knobs.
+
+## Recipes and Deployment Modes
+
+Defang has historically offered three fixed [deployment modes](./deployment-modes.md) — `affordable`, `balanced`, and `high_availability` — to let you trade off cost against resiliency. A recipe generalizes this idea: each of those modes is simply a built-in recipe, and recipes let you set the underlying infrastructure parameters directly instead of choosing from a fixed list. This means recipes supersede the enumerable deployment modes, while the three named modes remain available as convenient starting points.
+
+For example, on AWS, the built-in recipes set values like log retention (1 day for `affordable`, 7 for `balanced`, 30 for `high_availability`), the Fargate capacity provider (spot vs. on-demand), the number of availability zones, the NAT gateway strategy, and whether managed databases use burstable or memory-optimized classes.
+
+## Managing Recipes
+
+Recipes are managed in the [Defang Portal](./portal.md). You can start from one of the built-in recipes and adjust the parameters to suit a particular [stack](./stacks.md) — for instance, a development stack and a production stack of the same [project](./projects.md) can use different recipes.
+
+## How Recipes Are Used
+
+When you run a deployment with `defang up`, Defang sends two things to the Defang [`CD` task](/docs/intro/how-it-works) in your cloud:
+
+1. Your **project** — the Compose file(s) and uploaded sources.
+2. The **recipe** — the infrastructure parameters described above.
+
+The `CD` task passes the recipe to [Pulumi](./pulumi.md), which provisions and updates your cloud resources accordingly. In Pulumi terms, a recipe _is_ [Pulumi config](https://www.pulumi.com/docs/iac/concepts/config/): the configuration values consumed by the Defang Pulumi providers when they reconcile your deployment. Any parameter you omit from a recipe falls back to its built-in default at deployment time.

--- a/docs/concepts/recipe.md
+++ b/docs/concepts/recipe.md
@@ -17,6 +17,10 @@ You can select a built-in recipe with the `--mode` CLI flag, which defaults to `
 defang compose up --mode=high_availability
 ```
 
+:::tip
+The recommended way to pin a recipe is to configure a [stack](./stacks.md). A stack records the provider, region, and mode for a deployment, so you don't have to pass `--provider` or `--mode` on every command.
+:::
+
 For example, on AWS, the built-in recipes set values like log retention (1 day for `affordable`, 7 for `balanced`, 30 for `high_availability`), the Fargate capacity provider (spot vs. on-demand), the number of availability zones, the NAT gateway strategy, and whether managed databases use burstable or memory-optimized classes.
 
 ## Built-in Recipes

--- a/docs/concepts/recipe.md
+++ b/docs/concepts/recipe.md
@@ -11,7 +11,35 @@ A _recipe_ is the set of infrastructure-as-code parameters that Defang applies t
 
 Defang has historically offered three fixed [deployment modes](./deployment-modes.md) — `affordable`, `balanced`, and `high_availability` — to let you trade off cost against resiliency. A recipe generalizes this idea: each of those modes is simply a built-in recipe, and recipes let you set the underlying infrastructure parameters directly instead of choosing from a fixed list. This means recipes supersede the enumerable deployment modes, while the three named modes remain available as convenient starting points.
 
+You can select a built-in recipe with the `--mode` CLI flag, which defaults to `affordable`:
+
+```bash
+defang compose up --mode=high_availability
+```
+
 For example, on AWS, the built-in recipes set values like log retention (1 day for `affordable`, 7 for `balanced`, 30 for `high_availability`), the Fargate capacity provider (spot vs. on-demand), the number of availability zones, the NAT gateway strategy, and whether managed databases use burstable or memory-optimized classes.
+
+## Built-in Recipes
+
+The three built-in recipes balance cost and resiliency:
+
+* **Affordable**: Used for development and testing purposes. It typically involves less stringent resource allocations and may include debugging tools and verbose logging to aid in development.
+* **Balanced**: Serves as a pre-production environment where applications are tested in conditions that closely mimic production. It helps in identifying issues that might not be apparent in the development environment.
+* **High Availability**: Used for live deployments. It involves optimized configurations for performance, security, and reliability. Resource allocations are typically higher, and debugging tools are minimized to ensure stability.
+
+The following table compares what each built-in recipe configures:
+
+| Feature | Affordable | Balanced | High Availability |
+|-|-|-|-|
+| Build Resources | Builds will be run with 2x vCPUs |  (like `affordable`) | Builds will be run with 4x vCPUs |
+| Compute | Using spot instances | (like `affordable`) | On-demand instances |
+| Databases | Defang will provision resources optimized for burstable memory | (like `high_availability`) | Defang will provision resources optimized for production |
+| Deployment | Previous deployments will be spun down before new deployments are spun up. Stopped tasks will not restart. | (like `high_availability`) | Rolling updates will be used to deploy new versions. Defang will gradually replace services while maintaining at least [the original number of replicas](/docs/tutorials/scaling-your-services). |
+| Logs | Logs retained for 1 day to save costs. | Logs retained for 7 days to balance cost and access. | Logs retained for 30 days for compliance. |
+| Networking | Only public IPs | Defang will provision a single NAT gateway | Defang will provision multiple NAT gateways. |
+| Load Balancing | HTTP redirect to HTTPS using `302 Found` | | Termination Protection will be enabled; logs are retained on "down" |
+| DNS | Defang will provision shorter TTLs; zones will be forcefully destroyed | | Defang will provision longer TTLs; records can be overwritten for ZDT |
+| Managed Storage | Operations that cause downtime are allowed | | Encryption at rest; Final snapshot created on "down" |
 
 ## Managing Recipes
 

--- a/docs/concepts/stacks.md
+++ b/docs/concepts/stacks.md
@@ -8,6 +8,8 @@ description: Defang supports deploying multiple instances of a project as separa
 
 Defang supports deploying multiple instances of a project as separate _stacks_. Each stack represents an isolated deployment of your project. Stacks allow you to manage different deployments of your project. For example, you can use stacks to support distinct development, staging, and production environments in the same cloud account. You can also use stacks to support deployments for different customers (e.g., Client A, Client B) or regions (e.g., North America, Europe) within the same project.
 
+A stack records the cloud provider, region, and deployment mode (its [recipe](/docs/concepts/recipe)) for a deployment. This supersedes passing `--provider` and `--mode` on every command: instead of repeating those flags, you select a stack and Defang uses its recorded settings. The flags still work and override the stack's values when needed.
+
 :::info
 Stacks is a new feature introduced in Defang CLI v2.4.0 and is currently in preview. We welcome your feedback! Please open an issue on [GitHub](https://github.com/DefangLabs/defang/issues) if you encounter any problems or have suggestions.
 :::

--- a/docs/intro/how-it-works.mdx
+++ b/docs/intro/how-it-works.mdx
@@ -6,18 +6,18 @@ description: Overview of the Defang architecture and how it works in your cloud
 
 # How Defang Works
 
-Defang is an AI-assisted tool that lets you take your app from Docker Compose to a secure and scalable deployment on your favorite cloud in minutes. Defang abstracts away the complexity of cloud infrastructure, providing you with a streamlined experience. Defang works by provisioning a "CD" service and a small set of resources in your cloud account. These services enable Defang to orchestrate deployments for you in your cloud account from the `defang` CLI. Here's how it works.
+Defang is an AI-assisted tool that lets you take your app from Docker Compose to a secure and scalable deployment on your favorite cloud in minutes. Defang abstracts away the complexity of cloud infrastructure, providing you with a streamlined experience. Defang works by provisioning a "CD" task and a small set of resources in your cloud account. These enable Defang to orchestrate deployments for you in your cloud account from the `defang` CLI. Here's how it works.
 
 ## Bootstrapping
 
-The first time you deploy with Defang, a new `CD` service will be created in your cloud account. This service acts as an intermediary between you and your cloud provider. It will set up a grpc endpoint with which the `defang` CLI can communicate. When the CLI sends a request to trigger a deployment, for example, this service will orchestrate the build and deployment process—interfacing with the cloud APIs on your behalf. We will also create the necessary resources to support the Defang system. This includes things like roles, a storage space, an image repository, certificates, etc. The specific resources created depend on the cloud provider.
+The first time you deploy with Defang, a new `CD` task will be created in your cloud account. This task acts as an intermediary between you and your cloud provider. It will set up a grpc endpoint with which the `defang` CLI can communicate. When the CLI sends a request to trigger a deployment, for example, this task will orchestrate the build and deployment process—interfacing with the cloud APIs on your behalf. We will also create the necessary resources to support the Defang system. This includes things like roles, a storage space, an image repository, certificates, etc. The specific resources created depend on the cloud provider.
 
 Our architecture and AWS implementation has passed a ["well-architected"](https://docs.aws.amazon.com/wellarchitected/latest/framework/welcome.html) review. We are in the process for obtaining similar qualifications with Digital Ocean and Google Cloud.
 
 You can learn more about the specifics by visiting our [provider docs](/docs/providers).
 
 :::info
-The `CD` service does not run all the time. It is only used when you deploy a new service or update an existing service. Once it has finished deploying your service, it will shut itself down.
+The `CD` task does not run all the time. It is only used when you deploy a new service or update an existing service. Once it has finished deploying your service, it will shut itself down.
 :::
 
 ```mermaid
@@ -30,7 +30,7 @@ flowchart TD
 
   subgraph cloud["Cloud"]
     sdk(("SDK"))
-    CD(CD)
+    CD("CD task")
     kaniko(Kaniko)
 
     subgraph services[" "]
@@ -42,7 +42,7 @@ flowchart TD
 
 compose --> CLI
 
-CLI <--> CD
+CLI <-->|project + recipe| CD
 CD --> kaniko
 CD --> sdk
 sdk --> services
@@ -51,7 +51,7 @@ sdk --> services
 
 ## Orchestrating Deployments
 
-The Defang `CD` service acts as an intermediary between you and your cloud provider. This service receives deployment requests from the `defang` CLI. Once a request has been received, `CD` orchestrates the process of building application images from your source code, and then continues to provision the necessary resources to deploy your application.
+The Defang `CD` task acts as an intermediary between you and your cloud provider. This task receives deployment requests from the `defang` CLI. Each request carries your project (the Compose file(s) and source code) along with a [recipe](/docs/concepts/recipe) — the infrastructure-as-code parameters that aren't derived from your Compose file. Once a request has been received, `CD` orchestrates the process of building application images from your source code, and then continues to provision the necessary resources to deploy your application.
 
 :::info
 The `defang` CLI will upload your source code to a storage destination within your cloud. Your source code is never processed by Defang's servers.
@@ -59,9 +59,9 @@ The `defang` CLI will upload your source code to a storage destination within yo
 
 ## Building Images
 
-When you deploy a new service, Defang will build a Docker image from your source code. This source code is uploaded by the `defang` CLI to a storage destination in your cloud account. The Defang `CD` service will then retrieve it and determine if each of your service's images need to be rebuilt. If rebuilding is necessary, `CD` will start a new container for each build it needs to complete.
+When you deploy a new service, Defang will build a Docker image from your source code. This source code is uploaded by the `defang` CLI to a storage destination in your cloud account. The Defang `CD` task will then retrieve it and determine if each of your service's images need to be rebuilt. If rebuilding is necessary, `CD` will start a new container for each build it needs to complete.
 
-When you deploy an update to an existing service, the Defang `CD` service will determine if rebuilding your service's images is necessary. For example, when deploying new source code, `CD` will request that a new image be built. When deploying an update which does not require a new image, one will not be built—for example, redeploying the same service with increased or decreased resource requirements. In this case, the same image can be deployed to newly provisioned cloud resources.
+When you deploy an update to an existing service, the Defang `CD` task will determine if rebuilding your service's images is necessary. For example, when deploying new source code, `CD` will request that a new image be built. When deploying an update which does not require a new image, one will not be built—for example, redeploying the same service with increased or decreased resource requirements. In this case, the same image can be deployed to newly provisioned cloud resources.
 
 Defang uses [Kaniko](https://github.com/GoogleContainerTools/kaniko) to build your images in a container in your cloud account. The resulting images will be stored in your cloud account's private container registry for future reference.
 
@@ -70,4 +70,4 @@ Defang uses [Kaniko](https://github.com/GoogleContainerTools/kaniko) to build yo
 
 After your images have been built, `CD` will provision the necessary resources and deploy these images as new services in your cloud account. Defang uses the cloud provider's SDK to create the necessary resources for your services. This may include creating new containers, setting up networking, and configuring any other resources your services needs, such as storage resources.
 
-When deploying changes to existing services, the `CD` service will determine the minimum set of changes necessary and add, remove, replace, or update services as necessary.
+When deploying changes to existing services, the `CD` task will determine the minimum set of changes necessary and add, remove, replace, or update services as necessary.

--- a/docs/tutorials/updating-your-services.md
+++ b/docs/tutorials/updating-your-services.md
@@ -23,6 +23,10 @@ Defang offers multiple [deployment modes](/docs/concepts/deployment-modes). You 
 $ defang compose up --mode=production
 ```
 
+:::tip
+Rather than passing `--mode` (and `--provider`) on every deploy, configure a [stack](/docs/concepts/stacks), which records the provider, region, and mode for a deployment. The flags still work and override the stack when needed.
+:::
+
 ### Development Mode (Default)
 
 The default deployment mode is `development`. This is the In this mode, the existing services will be deprovisioned before your new service will be spun up. This means that there will be a short downtime while the new service is being provisioned.


### PR DESCRIPTION
Add a Recipe concept doc explaining recipes as the infrastructure-as-code parameters not derived from the Compose file, how they supersede the fixed deployment modes, and how they flow to the CD task as Pulumi config.

In how-it-works, refer to the Defang CD component as a "task" (accurate for BYOC) rather than a "service", update the architecture chart, and add a backlink to the new Recipe doc.