### PR TITLE
Add blog post: The AI-Native Enterprise

### DIFF
--- a/blog/2026-07-15-ai-native-enterprise.md
+++ b/blog/2026-07-15-ai-native-enterprise.md
@@ -1,0 +1,94 @@
+---
+title: "The AI-Native Enterprise: Redesigning Engineering for the AI Era"
+description: "Why the next wave of engineering advantage won't come from adopting another AI tool, but from redesigning engineering around humans and AI agents working together."
+slug: ai-native-enterprise
+tags: [AI, AI-Native, Engineering, Agents, DevOps, Cloud]
+authors: defang_team
+date: 2026-07-15
+---
+
+Every decade or so, our industry experiences a shift that fundamentally changes how software is built.
+
+The cloud changed **where** software runs. Mobile changed **where** people work. AI is changing **how work itself is organized**.
+
+For the first time, engineering organizations have access to a new kind of teammate: AI agents that can reason, plan, write code, analyze information, operate systems, and execute increasingly complex tasks alongside humans.
+
+{/* truncate */}
+
+The opportunity isn't simply to automate existing work. It is to redesign engineering workflows around teams of humans and AI agents, each contributing what they do best. The organizations that embrace this shift won't just build software faster—they'll organize engineering differently.
+
+We call these organizations **AI-native enterprises**.
+
+## What Is an AI-Native Enterprise?
+
+Many organizations think AI adoption means giving developers access to coding assistants or building a few internal chatbots. Those are valuable first steps, but they are only incremental improvements.
+
+An AI-native engineering organization asks a different question:
+
+> If we were designing this engineering organization today, knowing AI agents exist, how would we build it?
+
+That question changes everything.
+
+Instead of layering AI onto existing processes, AI-native organizations rethink how software is planned, built, tested, deployed, operated, secured, and continuously improved. Engineers spend less time executing routine tasks and more time defining intent, making architectural decisions, reviewing outcomes, and orchestrating increasingly capable AI systems.
+
+The goal isn't to replace engineers. It's to redesign engineering so that humans and AI agents work together as a single adaptive system.
+
+Like every major technology transition, this transformation happens gradually. At Defang, we think of it as the **AI-Native Maturity Model**.
+
+| Stage | Maturity | Engineering Organization |
+| --- | --- | --- |
+| 0 | Resistant | AI is prohibited or ignored. Engineering remains entirely human-driven. |
+| 1 | Curious | Individual engineers experiment with AI independently. |
+| 2 | Assisted | AI improves individual productivity through coding assistants and personal AI tools. |
+| 3 | Managed | Organization-wide AI standards, governance, and approved tooling are established. |
+| 4 | Integrated | AI is embedded throughout the software development lifecycle, from design and coding to testing, documentation, and reviews. |
+| 5 | Delegated | Well-defined engineering tasks are delegated to specialized AI agents operating under human supervision. |
+| 6 | Operational | AI agents become trusted participants in deployments, operations, monitoring, and enterprise workflows. |
+| 7 | Collaborative | Engineering teams coordinate multiple specialized AI agents across development, operations, security, testing, and support. |
+| 8 | AI-First | Engineering workflows are redesigned around humans and AI agents working together from the outset. |
+| 9 | Adaptive | AI continuously improves engineering systems and processes while humans provide strategy, governance, and oversight. |
+| 10 | AI-Native | Humans and AI agents function as a single adaptive engineering organization that continuously learns and evolves. |
+
+Today, most organizations are somewhere between the **Assisted** and **Integrated** stages. The next wave of competitive advantage won't come from adopting another AI tool. It will come from progressing through the higher stages of this maturity model.
+
+## Engineering the AI-Native Enterprise
+
+The early stages of AI adoption are relatively straightforward. Developers gain access to coding assistants, teams experiment with AI-powered tools, and productivity improves.
+
+The real transformation begins when AI moves beyond assisting individual engineers and starts participating directly in engineering workflows. AI agents are no longer just tools—they become active participants in the engineering organization. They need secure identities, access to enterprise systems, deployment pipelines, governance, observability, and operational controls. Building and operating these systems is fundamentally an engineering challenge, not simply a tooling decision.
+
+As organizations make this transition, they also create a new strategic asset: institutional intelligence. Every workflow they redesign, every prompt they refine, every evaluation they perform, every AI agent they develop, and every operational lesson they learn becomes part of the organization's intellectual property. Over time, this accumulated knowledge becomes one of its most valuable competitive advantages.
+
+This is why we believe becoming AI-native also requires **engineering sovereignty**.
+
+Engineering sovereignty means retaining ownership of the systems that make your business unique. Your data. Your workflows. Your AI agents. Your deployment architecture. Your operational knowledge. Your intellectual property. It also means preserving the freedom to choose the cloud and model providers that best fit each workload, rather than becoming dependent on a single vendor's ecosystem.
+
+AI models will evolve. Cloud platforms will evolve. New infrastructure will emerge. The organizations that thrive will be those whose architecture allows them to adopt these innovations without surrendering control over the intelligence they have created.
+
+## Defang's Mission
+
+At Defang, our mission is to help engineering organizations become AI-native while preserving engineering sovereignty.
+
+The Defang Platform enables organizations to deploy AI applications and agents into their own AWS, Azure, or Google Cloud environments while remaining independent of any single cloud or model provider. Customers retain ownership of their infrastructure, their data, and the engineering systems they build, allowing their institutional intelligence to compound into a durable competitive advantage.
+
+Technology, however, is only part of the journey.
+
+Through Defang Forge, we work alongside engineering organizations to assess their AI maturity, redesign engineering workflows, build production-grade AI systems, and accelerate their transition to becoming AI-native. Our objective is not simply to help customers deploy AI, but to help them rethink how engineering works in the AI era.
+
+## Looking Ahead
+
+Cloud-native wasn't simply about moving servers into the cloud. It fundamentally changed how software was designed, built, and operated.
+
+AI-native will be an equally significant transformation.
+
+The organizations that succeed won't simply use more AI. They'll redesign engineering around humans and AI agents working together, preserve ownership of the knowledge and intellectual property that differentiate their business, and continuously evolve as AI technology advances.
+
+We believe every engineering organization will eventually become AI-native.
+
+The question isn't whether that transformation will happen.
+
+It's whether you'll build it on a foundation that preserves the freedom to evolve.
+
+**Become AI-native. Remain sovereign.**
+
+That's the future Defang is building for.


### PR DESCRIPTION
## Summary
- Adds a new blog post introducing Defang's AI-Native Maturity Model and the concept of engineering sovereignty for organizations adopting AI agents.

## Test plan
- [x] Verified YAML frontmatter parses correctly with gray-matter
- [x] Verified post body compiles as valid MDX
- [ ] Full `npm run build` not run locally (requires sibling `defang` / `samples` repos only available in CI) — verify via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)